### PR TITLE
feat: blunderbuss supports re-cc to reviewers when sig label added

### DIFF
--- a/docs/src/plugins/blunderbuss.md
+++ b/docs/src/plugins/blunderbuss.md
@@ -58,4 +58,5 @@ ti-community-blunderbuss:
 ## Q&A
 
 ### 为什么我 /auto-cc 不会自动分配 reviewers？
+
 可能是因为你的仓库设置了 require_sig_label，导致在打上 sig 标签之前都不会自动分配 reviewers。

--- a/docs/src/plugins/blunderbuss.md
+++ b/docs/src/plugins/blunderbuss.md
@@ -6,7 +6,7 @@
 
 ti-community-blunderbuss 负责在 PR 创建时，根据 ti-community-owners 划分的权限自动分配 reviewers。除此之外，我们还需要考虑到如果 reviewers 长时间无回复时需要再次请求其他人 review  的情况，所以我们还支持了 `/auto-cc` 命令来触发再次分配 reviewers。
 
-实际上在一些 Github 仓库当中，绝大多数 PR 都需要带有 sig 标签，只有在添加了 sig 标签之后才能够自动分配 reviewers，所以我们需要通过插件加以限制，减少不必要的自动分配。
+实际上在一些 TiDB 社区的仓库当中，绝大多数 PR 都需要带有 sig 标签，只有在添加了 sig 标签之后才能够自动分配 reviewers，所以我们需要通过插件加以限制，减少不必要的自动分配。
 
 ## 权限设计
 
@@ -54,3 +54,8 @@ ti-community-blunderbuss:
 
 - [command help](https://prow.tidb.io/command-help?repo=ti-community-infra%2Fconfigs#auto_cc)
 - [代码实现](https://github.com/ti-community-infra/ti-community-prow/tree/master/internal/pkg/externalplugins/blunderbuss)
+
+## Q&A
+
+### 为什么我 /auto-cc 不会自动分配 reviewers？
+可能是因为你的仓库设置了 require_sig_label，导致在打上 sig 标签之前都不会自动分配 reviewers。

--- a/docs/src/plugins/blunderbuss.md
+++ b/docs/src/plugins/blunderbuss.md
@@ -6,6 +6,8 @@
 
 ti-community-blunderbuss 负责在 PR 创建时，根据 ti-community-owners 划分的权限自动分配 reviewers。除此之外，我们还需要考虑到如果 reviewers 长时间无回复时需要再次请求其他人 review  的情况，所以我们还支持了 `/auto-cc` 命令来触发再次分配 reviewers。
 
+实际上在一些 Github 仓库当中，绝大多数 PR 都需要带有 sig 标签，只有在添加了 sig 标签之后才能够自动分配 reviewers，所以我们需要通过插件加以限制，减少不必要的自动分配。
+
 ## 权限设计
 
 该插件主要负责 reviewers 的自动分配，所以我们将权限设置为 GitHub 用户都可以使用该功能。
@@ -14,15 +16,20 @@ ti-community-blunderbuss 负责在 PR 创建时，根据 ti-community-owners 划
 
 该插件主要参考了 Kubernetes 的 blunderbuss 插件设计。在它的基础上，我们依托于 ti-community-owners 实现当前 PR 的 reviewers 自动分配。
 
+当 PR 的 sig 标签发生变化时，插件会取消掉 PR 当前仍然处于 Pending 状态的 reviewers 的请求，重新获取 owners 中的 reviewers, 并重新分配 PR 的 reviewers。
+
+如果一个仓库要求 PR 都带有 sig 标签才能进行自动分配，在 PR 被添加上 sig 相关标签之前，创建 PR、对 PR 评论 `/auto-cc` 命令都不会进行自动分配。
+
 ## 参数配置
 
 | 参数名               | 类型     | 说明                                                        |
-| -------------------- | -------- | ----------------------------------------------------------- |
+| -------------------- | -------- | --------------------------------------------------------- |
 | repos                | []string | 配置生效仓库                                                |
-| pull_owners_endpoint | string   | PR owners RESTFUL 接口地址                                  |
+| pull_owners_endpoint | string   | PR owners RESTFUL 接口地址                                 |
 | max_request_count    | int      | 最多的分配人数                                              |
 | exclude_reviewers    | []string | 不参与自动分配的 reviewers（针对一些可能不活跃的 reviewers ）   |
 | grace_period_duration| int      | 配置等待其它插件添加 sig 标签的等待时间，单位为秒，默认为 5 秒    |
+| require_sig_label    | bool     | PR 是否必须带有 SIG 标签才允许自动分配 reviewers               |
 
 例如：
 
@@ -40,15 +47,10 @@ ti-community-blunderbuss:
       - sykp241095
       - AndreMouche
     grace_period_duration: 5
+    require_sig_label: true
 ```
 
 ## 参考文档
 
 - [command help](https://prow.tidb.io/command-help?repo=ti-community-infra%2Fconfigs#auto_cc)
 - [代码实现](https://github.com/ti-community-infra/ti-community-prow/tree/master/internal/pkg/externalplugins/blunderbuss)
-
-## Q&A
-
-### 如果我的 PR 更改了 sig 的 label 导致了 owners 中的 reviewers 发生了变动怎么办？
-
-目前我们还未做这部分支持，我们后续会根据 label 的变化自动更换 reviewers 的请求。

--- a/internal/pkg/externalplugins/blunderbuss/blunderbuss.go
+++ b/internal/pkg/externalplugins/blunderbuss/blunderbuss.go
@@ -99,8 +99,11 @@ func configString(maxReviewerCount int) string {
 func HandlePullRequestEvent(gc githubClient, pe *github.PullRequestEvent,
 	cfg *externalplugins.Configuration, ol ownersclient.OwnersLoader, log *logrus.Entry) error {
 	// Handle the event of adding the SIG label of open PR.
-	if pe.Action == github.PullRequestActionLabeled && pe.PullRequest.State == "open" &&
-		strings.Contains(pe.Label.Name, externalplugins.SigPrefix) {
+	if pe.PullRequest.State != "open" {
+		return nil
+	}
+
+	if pe.Action == github.PullRequestActionLabeled && strings.Contains(pe.Label.Name, externalplugins.SigPrefix) {
 		return handlePullRequestLabeled(gc, pe, cfg, ol, log)
 	}
 

--- a/internal/pkg/externalplugins/blunderbuss/blunderbuss.go
+++ b/internal/pkg/externalplugins/blunderbuss/blunderbuss.go
@@ -262,7 +262,7 @@ func getReviewers(author string, reviewers []string, excludeReviewers []string, 
 
 func containSigLabel(labels []github.Label) bool {
 	for _, label := range labels {
-		if strings.Contains(label.Name, externalplugins.SigPrefix) {
+		if strings.HasPrefix(label.Name, externalplugins.SigPrefix) {
 			return true
 		}
 	}

--- a/internal/pkg/externalplugins/blunderbuss/blunderbuss.go
+++ b/internal/pkg/externalplugins/blunderbuss/blunderbuss.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/test-infra/prow/pkg/layeredsets"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
-	assign "k8s.io/test-infra/prow/plugins/assign"
+	"k8s.io/test-infra/prow/plugins/assign"
 )
 
 const (

--- a/internal/pkg/externalplugins/blunderbuss/blunderbuss_test.go
+++ b/internal/pkg/externalplugins/blunderbuss/blunderbuss_test.go
@@ -283,7 +283,7 @@ func TestHandlePullRequest(t *testing.T) {
 		labels []string
 		// label specifies the label related to labeled and unlabeled events.
 		label string
-		// Whether to simulate other plugins in the sleep function to add tags to the current PR
+		// Whether to simulate other plugins add SIG label to the current PR in the sleep function.
 		mockOtherPluginAddSigLabel bool
 		requireSigLabel            bool
 		maxReviewersCount          int
@@ -414,7 +414,7 @@ func TestHandlePullRequest(t *testing.T) {
 
 		// Mock the sleep function.
 		sleep = func(time.Duration) {
-			// Simulate other plugins to add labels to PR
+			// Simulate other plugins to add SIG label to PR
 			if tc.mockOtherPluginAddSigLabel {
 				_ = fc.AddLabel("org", "repo", pr.Number, "sig/planner")
 			}
@@ -575,23 +575,23 @@ func TestHelpProvider(t *testing.T) {
 
 func TestContainIssueLabels(t *testing.T) {
 	testCases := []struct {
-		name         string
-		labelNames   []string
-		expectReturn bool
+		name        string
+		labelNames  []string
+		expectFound bool
 	}{
 		{
 			labelNames: []string{
 				"difficulty/hard",
 				"sig/planner",
 			},
-			expectReturn: true,
+			expectFound: true,
 		},
 		{
 			labelNames: []string{
 				"difficulty/hard",
 				"status/lgm1",
 			},
-			expectReturn: false,
+			expectFound: false,
 		},
 	}
 
@@ -600,8 +600,8 @@ func TestContainIssueLabels(t *testing.T) {
 			labels := mapLabelNameToLabel(tc.labelNames)
 			contain := containSigLabel(labels)
 
-			if contain != tc.expectReturn {
-				t.Fatalf("contain sig label judgment mismatch: got %v, want %v", contain, tc.expectReturn)
+			if contain != tc.expectFound {
+				t.Fatalf("contain sig label judgment mismatch: got %v, want %v", contain, tc.expectFound)
 			}
 		})
 	}

--- a/internal/pkg/externalplugins/blunderbuss/blunderbuss_test.go
+++ b/internal/pkg/externalplugins/blunderbuss/blunderbuss_test.go
@@ -284,11 +284,11 @@ func TestHandlePullRequest(t *testing.T) {
 		// label specifies the label related to labeled and unlabeled events.
 		label string
 		// Whether to simulate other plugins add SIG label to the current PR in the sleep function.
-		mockOtherPluginAddSigLabel bool
-		requireSigLabel            bool
-		maxReviewersCount          int
-		requestedReviewers         []string
-		excludeReviewers           []string
+		mockAddSigLabel    bool
+		requireSigLabel    bool
+		maxReviewersCount  int
+		requestedReviewers []string
+		excludeReviewers   []string
 
 		expectReviewerCount int
 	}{
@@ -313,24 +313,24 @@ func TestHandlePullRequest(t *testing.T) {
 		{
 			name: "PR does not require SIG label but other plugins add SIG label will not triggers " +
 				"the automatic assignment",
-			action:                     github.PullRequestActionOpened,
-			body:                       "/auto-cc",
-			state:                      "open",
-			mockOtherPluginAddSigLabel: true,
-			requireSigLabel:            false,
-			maxReviewersCount:          2,
-			expectReviewerCount:        0,
+			action:              github.PullRequestActionOpened,
+			body:                "/auto-cc",
+			state:               "open",
+			mockAddSigLabel:     true,
+			requireSigLabel:     false,
+			maxReviewersCount:   2,
+			expectReviewerCount: 0,
 		},
 		{
 			name: "PR does not require SIG label while other plugins do not add SIG label will trigger " +
 				"the automatic assignment",
-			action:                     github.PullRequestActionOpened,
-			body:                       "/auto-cc",
-			state:                      "open",
-			mockOtherPluginAddSigLabel: false,
-			requireSigLabel:            false,
-			maxReviewersCount:          2,
-			expectReviewerCount:        2,
+			action:              github.PullRequestActionOpened,
+			body:                "/auto-cc",
+			state:               "open",
+			mockAddSigLabel:     false,
+			requireSigLabel:     false,
+			maxReviewersCount:   2,
+			expectReviewerCount: 2,
 		},
 		{
 			name:                "PR opened with /cc command",
@@ -415,7 +415,7 @@ func TestHandlePullRequest(t *testing.T) {
 		// Mock the sleep function.
 		sleep = func(time.Duration) {
 			// Simulate other plugins to add SIG label to PR
-			if tc.mockOtherPluginAddSigLabel {
+			if tc.mockAddSigLabel {
 				_ = fc.AddLabel("org", "repo", pr.Number, "sig/planner")
 			}
 		}

--- a/internal/pkg/externalplugins/config.go
+++ b/internal/pkg/externalplugins/config.go
@@ -132,7 +132,7 @@ type TiCommunityBlunderbuss struct {
 	// GracePeriodDuration specifies the waiting time before the plugin requests a review,
 	// defaults to 5 means that the plugin will wait 5 seconds for the sig label to be added.
 	GracePeriodDuration int `json:"grace_period_duration,omitempty"`
-	// RequireSigLabel specifies whether the PR is required to have a SIG label before requesting reviewers.
+	// RequireSigLabel specifies whether the PR is required to have a sig label before requesting reviewers.
 	RequireSigLabel bool `json:"require_sig_label,omitempty"`
 }
 

--- a/internal/pkg/externalplugins/config.go
+++ b/internal/pkg/externalplugins/config.go
@@ -309,6 +309,7 @@ func (c *TiCommunityBlunderbuss) setDefaults() {
 
 // Validate will return an error if there are any invalid external plugin config.
 func (c *Configuration) Validate() error {
+	// TODO: Put the setDefaults function in a more suitable place.
 	// Defaulting should run before validation.
 	c.setDefaults()
 

--- a/internal/pkg/externalplugins/config_test.go
+++ b/internal/pkg/externalplugins/config_test.go
@@ -723,3 +723,43 @@ func TestTarsFor(t *testing.T) {
 		})
 	}
 }
+
+func TestSetBlunderbussDefaults(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		gracePeriodDuration       int
+		expectGracePeriodDuration int
+	}{
+		{
+			name:                      "default",
+			gracePeriodDuration:       0,
+			expectGracePeriodDuration: 5,
+		},
+		{
+			name:                      "overwrite",
+			gracePeriodDuration:       3,
+			expectGracePeriodDuration: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Configuration{
+				TiCommunityBlunderbuss: []TiCommunityBlunderbuss{
+					{
+						GracePeriodDuration: tc.gracePeriodDuration,
+					},
+				},
+			}
+
+			c.setDefaults()
+
+			for _, blunderbuss := range c.TiCommunityBlunderbuss {
+				if blunderbuss.GracePeriodDuration != tc.expectGracePeriodDuration {
+					t.Errorf("unexpected grace_period_duration: %v, expected: %v",
+						blunderbuss.GracePeriodDuration, tc.expectGracePeriodDuration)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### TODO
- [ ] Through testing in the dev server, it is determined that the plugin cancels all reviewers in the PENDING state, not all reviewers

### Notice
The current solution is to only listen to labeled events, but there are still problems: 
If a PR only cancels the sig tag without reassigning a new sig tag, for example: if a PR mistakenly adds a sig tag, and then cancels the sig tag, at this time, there will be a problem of not revoking the review request.

### Related
close #144 